### PR TITLE
Add clinical use disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ streamlit run app_medgemma_final.py
 - Ask a question about the image and receive a MedGemma 4B-powered response.
 - Uses Hugging Face Hub authentication via `HF_TOKEN`.
 
+## Clinical Use Disclaimer
+
+This application is intended for clinical decision support and is not a substitute for professional medical judgment.
+

--- a/app_medgemma_final.py
+++ b/app_medgemma_final.py
@@ -21,6 +21,11 @@ st.markdown(
     "and get an AI-powered analysis via Google’s MedGemma 4B."
 )
 
+# Persistent disclaimer about clinical use
+st.warning(
+    "This tool provides decision support only and is not a definitive diagnosis."
+)
+
 # — 3. Authenticate to Hugging Face —
 try:
     login(token=st.secrets["HF_TOKEN"])


### PR DESCRIPTION
## Summary
- Warn users within the app that it provides decision support only and is not a definitive diagnosis
- Document a clinical use disclaimer in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689547c1b83c832b836c4448ed68618d